### PR TITLE
Add BasePlanet gem path to project config

### DIFF
--- a/Project/project.json
+++ b/Project/project.json
@@ -14,7 +14,8 @@
     "icon_path": "preview.png",
     "engine": "o3de-sdk",
     "external_subdirectories": [
-        "Gem"
+        "Gem",
+        "../Gems/BasePlanet"
     ],
     "restricted": "Planet_Survival_Game",
     "gem_names": [


### PR DESCRIPTION
Hi ! From what I saw, if the BasePlanet gem path is not in your `.o3de/o3de_manifest.json` it will fail to find the gem and configure the project. Adding the path in the project config seems to fix the problem :)

Signed-off-by: Guillaume Haerinck <guillaume.haerinck@outlook.com>