### PR TITLE
Update readme and check project against 23.10

### DIFF
--- a/Project/Levels/Main/Main.prefab
+++ b/Project/Levels/Main/Main.prefab
@@ -150,7 +150,7 @@
                                     "guid": "{F90F6215-CA23-5506-89C3-4495539484FB}",
                                     "subId": 2884240345
                                 },
-                                "assetHint": "spaceships/mainplayerlandingship.pxmesh"
+                                "assetHint": "spaceships/mainplayerlandingship.fbx.pxmesh"
                             },
                             "Configuration": {
                                 "PhysicsAsset": {
@@ -159,7 +159,7 @@
                                         "subId": 2884240345
                                     },
                                     "loadBehavior": "QueueLoad",
-                                    "assetHint": "spaceships/mainplayerlandingship.pxmesh"
+                                    "assetHint": "spaceships/mainplayerlandingship.fbx.pxmesh"
                                 },
                                 "UseMaterialsFromAsset": false
                             }
@@ -212,7 +212,7 @@
                                     "guid": "{F90F6215-CA23-5506-89C3-4495539484FB}",
                                     "subId": 275605049
                                 },
-                                "assetHint": "spaceships/mainplayerlandingship.azmodel"
+                                "assetHint": "spaceships/mainplayerlandingship.fbx.azmodel"
                             }
                         }
                     }
@@ -302,8 +302,7 @@
                     "Id": 16880285896855930892,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 15.0,
-                            "EditorEntityId": 12658108405792767668
+                            "Field of View": 15.0
                         }
                     }
                 },
@@ -768,8 +767,7 @@
                     "Id": 16880285896855930892,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 15.0,
-                            "EditorEntityId": 15780345423945723115
+                            "Field of View": 15.0
                         }
                     }
                 },
@@ -833,8 +831,7 @@
                     "Id": 16880285896855930892,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 15.0,
-                            "EditorEntityId": 16131105122374429955
+                            "Field of View": 15.0
                         }
                     }
                 },
@@ -1820,8 +1817,7 @@
                     "Id": 16880285896855930892,
                     "Controller": {
                         "Configuration": {
-                            "Field of View": 15.0,
-                            "EditorEntityId": 9226876681054249903
+                            "Field of View": 15.0
                         }
                     }
                 },

--- a/Project/project.json
+++ b/Project/project.json
@@ -12,7 +12,7 @@
         "Planet_Survival_Game"
     ],
     "icon_path": "preview.png",
-    "engine": "o3de-sdk",
+    "engine": "o3de",
     "external_subdirectories": [
         "Gem",
         "../Gems/BasePlanet"
@@ -20,5 +20,6 @@
     "restricted": "Planet_Survival_Game",
     "gem_names": [
         "BasePlanet"
-    ]
+    ],
+    "engine_version": "2.2.2"
 }

--- a/Project/project.json.bak0
+++ b/Project/project.json.bak0
@@ -1,0 +1,24 @@
+{
+    "project_name": "Planet_Survival_Game",
+    "project_id": "{EEB91659-9D39-41AF-8BCD-A0398B3CDFB6}",
+    "origin": "The primary repo for Planet_Survival_Game goes here: i.e. http://www.mydomain.com",
+    "license": "What license Planet_Survival_Game uses goes here: i.e. https://opensource.org/licenses/Apache-2.0 Or https://opensource.org/licenses/MIT etc.",
+    "display_name": "Planet_Survival_Game",
+    "summary": "A short description of Planet_Survival_Game.",
+    "canonical_tags": [
+        "Project"
+    ],
+    "user_tags": [
+        "Planet_Survival_Game"
+    ],
+    "icon_path": "preview.png",
+    "engine": "o3de-sdk",
+    "external_subdirectories": [
+        "Gem",
+        "../Gems/BasePlanet"
+    ],
+    "restricted": "Planet_Survival_Game",
+    "gem_names": [
+        "BasePlanet"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,212 +1,59 @@
-# Planet Survival Game - Proof of Concept Point and Click, Turn Based Strategy Game.
+<u>Supported o3de versions</u> : **23.10**
 
-# By Starr Shaw
-
-Project Or Game Description:
-
-Planet Survival Game is a Proof of concept Point and Click Turn Based Strategy Game. We start by landing on planet environment tile, with limited fuel, our first mission is to recharge are ship with locating a natural power on the planet in the form of Power Crystals. The Local residence of this area might not like this and attempt to stop this energy collection grab. We must explore the planet and find resources. The Planet is made of of procedural crafted squares with a variety of enemy encounters, puzzles, and task to perform. If you run out of power completely, or attack and loose an enemy fight, the game ends.
-
-https://user-images.githubusercontent.com/87207603/201387109-4a65bdb9-7f70-43f3-8ab0-f47d8416ba1f.mp4
-
-## The Project Includes
+# Planet Survival Game: Point and Click, Turn Based Strategy Game (By Starr Shaw)
 
 ![GamePlay](https://user-images.githubusercontent.com/87207603/201390591-a88dd221-f9d2-4046-9a25-2d4b92052924.gif)
+
+This game is a proof of concept for a 3D Point and Click, Turn Based Strategy Game. 
+
+We start by landing on planet environment tile, with limited fuel, our first mission is to recharge are ship with locating a natural power on the planet in the form of Power Crystals. The Local residence of this area might not like this and attempt to stop this energy collection grab. We must explore the planet and find resources. The Planet is made of of procedural crafted squares with a variety of enemy encounters, puzzles, and task to perform. If you run out of power completely, or attack and loose an enemy fight, the game ends.
+
+## Prerequisites
+
+You need to build or [install O3DE engine](https://o3de.org/download/).
+
+## How to run
+
+1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/PlanetSurvivalGame.git`)
+2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
+3. Navigate to your download (and make sure it is unzipped). Open the **Project** folder. The project should now be registered.
+
+![image](https://user-images.githubusercontent.com/87207603/201396468-0a13c0f8-8028-4121-bc4b-f4a36cf6c780.png)
+
+4. Click on the **Build Project** button, located on the **Planet_Survival_Game** image.
+5. Once the project has been built sucessfully, use the **Open Editor** button.
+6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window, simply pick the first one.
+
+## Controls
+
+The Main Player model can be moved around the level using Left Mouse Clicks.
+The Main Player UI next to the helmet will show how many moves are left. Once all moves are out the End Turn on the upper left will turn green.
+
+## Project Highlights
+
+<video controls src="https://user-images.githubusercontent.com/87207603/201387109-4a65bdb9-7f70-43f3-8ab0-f47d8416ba1f.mp4" title="## "></video>
 
 - **Planet environment**, includes Many Size Rocks, Plants, Lava Spouts and Main Playing Island Grid.
 - **Alien Explorer**, a ready to use character model, with multiple character animations such as, walk and attack. Is modular with Many Skin Attachments.
 - **AI Player**, The Buggy AI Character will use the Nav Mesh to seek and move toward your Player character.
 - **Script Canvas Visual Scripts,** editable Script Canvas visual scripts for main and in game menu interaction, gameplay and player movement.
+- **Build dynamic levels with O3DE Vegetation System**
 
-
-- Main Player
+### Screenshots
 
 ![Main_Char](https://user-images.githubusercontent.com/87207603/201388588-d6bc5874-3e3e-4724-b8cc-e50b0fb8921b.gif)
 
-- In-Game Screen Shot 1
 ![image(2)](https://user-images.githubusercontent.com/87207603/201387806-88ade873-1bbf-4f7a-a2d1-c1fad25cc6c1.png)
-- In-Game Screen Shot 2
-![image(3)](https://user-images.githubusercontent.com/87207603/201387824-baa998fa-1bd3-467f-9fc2-d170633ed1f1.png)
-- In-Game Screen Shot 3
-![image(6)](https://user-images.githubusercontent.com/87207603/201387893-7b570b7e-ccb6-45d5-a016-51e2ec35d233.png)
 
+![image(3)](https://user-images.githubusercontent.com/87207603/201387824-baa998fa-1bd3-467f-9fc2-d170633ed1f1.png)
+
+![image(6)](https://user-images.githubusercontent.com/87207603/201387893-7b570b7e-ccb6-45d5-a016-51e2ec35d233.png)
 
 https://user-images.githubusercontent.com/87207603/201387317-6cfdab7f-df73-40d4-98ed-80b477a3d8bb.mp4
 
-
-## Build Levels Dynamically
-Build dynamic levels with O3DE Vegetation System
-
 https://user-images.githubusercontent.com/87207603/201395614-0cf91fd3-a144-44f2-90f2-0d5e771826d2.mp4
 
-## Game Levels
-
-- **Main**, a start level and main gameplay level for a full game loop.
-
-## Requirements
-
-### Platforms
-
-The project supports the following platforms:
-
-- **Windows 10 version 1809 (10.0.17763)** or later is required.
-
-## O3DE Installation
-
-1. Refer to the [O3DE System Requirements](https://www.o3de.org/docs/welcome-guide/requirements/) documentation to make sure that the system/hardware requirements are met.
-2. Please follow the instructions to [set up O3DE from GitHub](https://o3de.org/docs/welcome-guide/setup/setup-from-github/).
-3. **Use the development branch**: git checkout development.
-
-# Building the project
-
-## Build Steps
-
-1. Clone the PlanetSurvivalGame game project from the following repo:
-   1. git clone https://github.com/o3de/PlanetSurvivalGame
-2. Within the Project manager locate and click on the **New Project** button. Then from the drop down menu select the **Open Existing Project** option.
-3. Once Windows Explorer opens, navigate to and select the **Planet_Survival_Game** folder. Once selected click on the **Select Folder** button.
-4. This will load the **Planet_Survival_Game** project into the **Project Manager**.
-![image](https://user-images.githubusercontent.com/87207603/201396468-0a13c0f8-8028-4121-bc4b-f4a36cf6c780.png)
-6. In order to build the project, locate and click on the **Build Project** button, located on the **Planet_Survival_Game** icon.
-
-
-## Launching the Project
-
-1. Once the project has been built sucessfully, the **Build Project** button will disappear and an **Open Editor** button should be the only option you can select.
-2. Click on the **Open Editor** button this will open the **Planet_Survival_Game** project.
-
-## Opening the Gameplay Level
-
-1. Once the Asset Processor has completed importing and processing a signifgance portion of the assets the O3DE Editor will open.
-2. In the **Welcome to O3DE** splash screen select the **Open** button to open a new level.
-3. This will open the **Open a Level** window
-4. Select the Main level and click the open level to launch the level.
-5. Once the level opens, the menu splash screen will ask you to mouse click to start the game.
-
-**Controlling the Main Player**
-
-**Navigation**
-
-1. **The Main Player model can be moved around the level using Left Mouse Clicks.**
-
-**Ending Turn**
-
-1. The Main Player UI next to helment will show how many moves are left. Once all moves are out the End Turn on the upper left will turn green.
-
-**License**
+## License
 
 For terms please see the LICENSE\*.TXT files at the root of this repository.
-
-For the sake of clarification licensing information can be also be found below.
-
-| OPEN 3D ENGINE LICENSING |
-| ------------------------ |
-|                          |
-
-| The default license for Open 3D Engine is the Apache License, Version 2.0 |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-| (see LICENSE_APACHE2.TXT); you may elect at your option to use the Open 3D |
-| -------------------------------------------------------------------------- |
-|                                                                            |
-
-| Engine under the MIT License (see LICENSE_MIT.TXT). Contributions must be |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-| made under both licenses. |
-| ------------------------- |
-|                           |
-
-|     |
-| --- |
-|     |
-
-| THIRD PARTY COMPONENTS |
-| ---------------------- |
-|                        |
-
-| Open 3D Engine requires the use of (and in some cases makes available to you) |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| software and assets that have been developed by third parties and are subject |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| to separate license terms (such as code licensed under other open source |
-| ------------------------------------------------------------------------ |
-|                                                                          |
-
-| licenses). It is your responsibility to comply with the applicable licenses. |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| Information on third party materials, and the applicable license terms, are |
-| --------------------------------------------------------------------------- |
-|                                                                             |
-
-| referenced in or included with the materials, such as in separate LICENSE.txt |
-| ----------------------------------------------------------------------------- |
-|                                                                               |
-
-| files accompanying the materials. |
-| --------------------------------- |
-|                                   |
-
-|     |
-| --- |
-|     |
-
-| Please note that certain materials are subject to "copyleft" licenses, which |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| require distribution of source code, including: |
-| ----------------------------------------------- |
-|                                                 |
-
-|     |
-| --- |
-|     |
-
-| - Qt Toolkit https://github.com/qtproject/, which is subject to the GNU |
-| ----------------------------------------------------------------------- |
-|                                                                         |
-
-| Lesser General Public License version 3 (with certain exceptions). A copy of |
-| ---------------------------------------------------------------------------- |
-|                                                                              |
-
-| the source code for Qt Toolkit may be found at |
-| ---------------------------------------------- |
-|                                                |
-
-| https://s3-us-west-2.amazonaws.com/ly-legal/LicenseConformance/Qt/Src.zip |
-| ------------------------------------------------------------------------- |
-|                                                                           |
-
-|     |
-| --- |
-|     |
-
-| - The AWS Python SDK uses Chardet https://chardet.github.io/, which is |
-| ---------------------------------------------------------------------- |
-|                                                                        |
-
-| subject to the GNU Lesser General Public License version 2.1. A copy of the |
-| --------------------------------------------------------------------------- |
-|                                                                             |
-
-source code may be found at https://github.com/chardet/chardet.
-
-| -  recastnavigation |
-| ------------------- |
-|                     |
-
-| recastnavigation/recastnavigation is licensed under the zlib License |
-| -------------------------------------------------------------------- |
-|                                                                      |
-
-https://github.com/recastnavigation/recastnavigation/blob/master/License.txt
-
+Recastnavigation is licensed under the [zlib License](https://github.com/recastnavigation/recastnavigation/blob/master/License.txt)

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ We start by landing on planet environment tile, with limited fuel, our first mis
 
 You need to build or [install O3DE engine](https://o3de.org/download/).
 
+You need to [install git with lfs support](https://git-scm.com/downloads), and [setup a token on your github account](https://www.docs.o3de.org/docs/welcome-guide/setup/setup-from-github/#configure-credentials-for-git-lfs). Needed as the repository uses Git LFS, the "Download ZIP" button will not download assets.
+
 ## How to run
 
-1. Download (green "Code" button, then "Download ZIP") or clone the github repository (`git clone https://github.com/o3de/PlanetSurvivalGame.git`)
+1. Clone the github repository (`git clone https://github.com/o3de/PlanetSurvivalGame.git`). When prompted to authenticate, use your github username and the token as password.
 2. Launch O3DE. It will open the Project manager. Click on the **New Project** button then **Open Existing Project** option.
-3. Navigate to your download (and make sure it is unzipped). Open the **Project** folder. The project should now be registered.
+3. Navigate to the cloned repository. Open the **Project** folder. The project should now be registered.
 
 ![image](https://user-images.githubusercontent.com/87207603/201396468-0a13c0f8-8028-4121-bc4b-f4a36cf6c780.png)
 
 4. Click on the **Build Project** button, located on the **Planet_Survival_Game** image.
-5. Once the project has been built sucessfully, use the **Open Editor** button.
+5. Once the project has been built successfully, use the **Open Editor** button.
 6. The asset pre-processor will run for a bit. Once it is over you will be welcomed with the **Open a Level** window, simply pick the first one.
 
 ## Controls


### PR DESCRIPTION
First take on an unified readme format used accross every O3DE samples (and checked that the project still runs correctly on the release of 23.10.3)

The goal being to make the samples more accessible to the users. Both by updating the project's readme, adding a version check and linking them in O3DE showcase and doc pages. Task tracked via this issue : https://github.com/o3de/o3de.org/issues/2549